### PR TITLE
chore: drop inapplicable dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,3 @@ updates:
         patterns: ["*"]
     versioning-strategy: increase
     labels: ["dependencies", "security"]
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"


### PR DESCRIPTION
phase-01 rollout (2026-05-23) flagged `github_actions` ecosystem failing with `dependency_file_not_found` on these repos (no `.github/workflows/` exists). Drop the block to stop recurring Dependabot job failures.